### PR TITLE
Add functionality to check OS

### DIFF
--- a/command/command_test.hcl
+++ b/command/command_test.hcl
@@ -17,3 +17,17 @@ unittest "SSH Command Test" {
         }
     }
 }
+
+unittest "SSH Command Test 2" {
+    image = "bpalmer/ssh_test"
+    port = "9090"
+    containerName = "hades-ssh-test"
+
+    run {
+        command {
+            name = "echo"
+            args = ["World Hello!"]
+            expectedOutput = "World Hello!"
+        }
+    }
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 )
 
 func main() {

--- a/os/os_test.go
+++ b/os/os_test.go
@@ -1,22 +1,31 @@
-package command
+package os
 
 import (
-	"strings"
-
 	"testing"
+	"time"
 
 	"github.com/everettraven/hades/utils"
+	"golang.org/x/crypto/ssh"
+
+	"strings"
 )
 
-//TestCommand - Unit test the command function
-func TestCommand(t *testing.T) {
+func TestOS(t *testing.T) {
 	t.Log("Parsing test HCL file")
 	// Parse the tests from the HCL file
-	unitTests, err := utils.ParseUnitTests("command_test.hcl")
+	unitTests, err := utils.ParseUnitTests("os_test.hcl")
 
 	// Make sure we didn't hit any errors while parsing the HCL file
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// Set up the SSH config for testing
+	config := &ssh.ClientConfig{
+		User:            "root",
+		Auth:            []ssh.AuthMethod{ssh.Password("root")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         30 * time.Second,
 	}
 
 	// Loop through all the tests we parsed
@@ -67,31 +76,34 @@ func TestCommand(t *testing.T) {
 		t.Logf("SSH is running in the container")
 
 		// Actual test implementation
-		//--------------------------------------------------------------------------------------
+		//-----------------------------------------------------------------------------------------------------
 
-		// Loop through all the command blocks in the test
-		for j := 0; j < len(curTest.Run.Cmd); j++ {
-			// Attempt to run the "remote" command
-			arguments := strings.Join(curTest.Run.Cmd[j].Arguments, " ")
-			command, err := TestRemoteCommand("127.0.0.1", curTest.Port, curTest.Run.Cmd[j].Name, arguments)
+		// Get the details from the operating system on the remote machine
+		osDetails, err := utils.GetRemoteOS("127.0.0.1", curTest.Port, config)
 
-			// If we encountered any errors lets handle it.
-			if err != nil {
-				// Set the failure message
-				t.Fatalf(err.Error())
-			} else {
-				testOutput := strings.TrimSpace(command.Stdout.String())
-				// Check to see if the output from running the command matches the expected output
-				if testOutput != curTest.Run.Cmd[j].ExpectedOutput {
-					// Set the failure message
-					t.Errorf("Output of the test did not match the Expected Output (Output: %s | Expected: %s)", testOutput, curTest.Run.Cmd[j].ExpectedOutput)
-				} else {
-					t.Logf("Command \"%s\" - Passed", command.Name+" "+arguments)
-				}
+		// Check for any errors
+		if err != nil {
+			t.Error(err.Error())
+		}
+
+		// Parse the returned OS info for the distro and version
+		details := strings.Split(osDetails, ":")
+		distro := details[0]
+		version := details[1]
+
+		// test to see if it matches the expected distro
+		if strings.ToLower(curTest.Run.Os.DistributionID) != strings.ToLower(distro) {
+			t.Errorf("OS of the remote machine does not match the expected value: Remote OS: %s", distro)
+		}
+
+		// test to see if it matches the expected version
+		if curTest.Run.Os.Version != "" {
+			if strings.ToLower(curTest.Run.Os.Version) != strings.ToLower(version) {
+				t.Errorf("OS version of the remote machine does not match the expected value: Remote OS Version: %s", version)
 			}
 		}
 
-		//--------------------------------------------------------------------------------------
+		//-----------------------------------------------------------------------------------------------------
 
 		t.Logf("Stopping Docker Container %s", curTest.ContainerName)
 		if err = curTest.StopContainer(); err != nil {

--- a/os/os_test.hcl
+++ b/os/os_test.hcl
@@ -1,0 +1,24 @@
+unittest "OS Check Test without Version" {
+    image = "bpalmer/ssh_test"
+    port = "9090"
+    containerName = "hades-os-test"
+
+    run {
+        os {
+            distributionID = "ubuntu"
+        }
+    }
+}
+
+unittest "OS Check Test with Version" {
+    image = "bpalmer/ssh_test"
+    port = "9090"
+    containerName = "hades-os-test-version"
+
+    run {
+        os {
+            distributionID = "ubuntu"
+            version = "20.04"
+        }
+    }
+}

--- a/utils/os.go
+++ b/utils/os.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"golang.org/x/crypto/ssh"
+	"fmt"
+	"errors"
+	"strings"
+)
+
+type OS struct {
+	DistributionID string `hcl:"distributionID"`
+	Version	string	`hcl:"version,optional"`
+}
+
+//GetRemoteOS - Function to determine the operating system of the remote system
+func GetRemoteOS(host string, port string, config *ssh.ClientConfig) (string, error) {
+	command := NewCommand("cat", "/etc/*-release")
+
+	endpoint := fmt.Sprintf("%s:%s", host, port)
+
+	client, err := ssh.Dial("tcp", endpoint, config)
+
+	if err != nil {
+		return "", errors.New("Could not establish a connection to the specified host. Error: " + err.Error())
+	}
+
+	err = command.RunRemote(client)
+
+	if err != nil {
+		return "", errors.New("Could not properly run the remote command specified. Error: " + err.Error())
+	}
+
+	output := command.Stdout.String()
+
+	details := strings.Split(output, "\n")
+
+	distrib := strings.TrimSpace(strings.Split(details[0], "=")[1])
+
+	version := strings.TrimSpace(strings.Split(details[1], "=")[1])
+
+	output = distrib + ":" + version
+
+	return output, nil
+}

--- a/utils/test_utils.go
+++ b/utils/test_utils.go
@@ -15,7 +15,8 @@ import (
 
 // RunBlock is a struct to hold the data of a run block of a test
 type RunBlock struct {
-	Cmd []Command `hcl:"command,block"`
+	Cmd []*Command `hcl:"command,block"`
+	Os	*OS	`hcl:"os,block"`
 }
 
 // UnitTestUtil is a struct to hold our test data.


### PR DESCRIPTION
## Type of Change
- [x] Test
- [x] Feature
- [ ] Internal Component
- [ ] Other

## Reason for Change
Added functionality to check the OS of the remote system. Currently has only been tested on an Ubuntu installation. More tests will be developed in the future to ensure that it works on multiple distributions, but this lays the foundation for this feature.