### PR TITLE
reorganize project structure

### DIFF
--- a/resources/command.go
+++ b/resources/command.go
@@ -1,4 +1,4 @@
-package utils
+package resources
 
 import (
 	"bytes"

--- a/resources/os.go
+++ b/resources/os.go
@@ -1,15 +1,16 @@
-package utils
+package resources
 
 import (
-	"golang.org/x/crypto/ssh"
-	"fmt"
 	"errors"
+	"fmt"
 	"strings"
+
+	"golang.org/x/crypto/ssh"
 )
 
 type OS struct {
 	DistributionID string `hcl:"distributionID"`
-	Version	string	`hcl:"version,optional"`
+	Version        string `hcl:"version,optional"`
 }
 
 //GetRemoteOS - Function to determine the operating system of the remote system

--- a/tests/command/command_test.go
+++ b/tests/command/command_test.go
@@ -1,31 +1,22 @@
-package os
+package command
 
 import (
+	"strings"
+
 	"testing"
-	"time"
 
 	"github.com/everettraven/hades/utils"
-	"golang.org/x/crypto/ssh"
-
-	"strings"
 )
 
-func TestOS(t *testing.T) {
+//TestCommand - Unit test the command function
+func TestCommand(t *testing.T) {
 	t.Log("Parsing test HCL file")
 	// Parse the tests from the HCL file
-	unitTests, err := utils.ParseUnitTests("os_test.hcl")
+	unitTests, err := utils.ParseUnitTests("command_test.hcl")
 
 	// Make sure we didn't hit any errors while parsing the HCL file
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	// Set up the SSH config for testing
-	config := &ssh.ClientConfig{
-		User:            "root",
-		Auth:            []ssh.AuthMethod{ssh.Password("root")},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Timeout:         30 * time.Second,
 	}
 
 	// Loop through all the tests we parsed
@@ -76,34 +67,31 @@ func TestOS(t *testing.T) {
 		t.Logf("SSH is running in the container")
 
 		// Actual test implementation
-		//-----------------------------------------------------------------------------------------------------
+		//--------------------------------------------------------------------------------------
 
-		// Get the details from the operating system on the remote machine
-		osDetails, err := utils.GetRemoteOS("127.0.0.1", curTest.Port, config)
+		// Loop through all the command blocks in the test
+		for j := 0; j < len(curTest.Run.Cmd); j++ {
+			// Attempt to run the "remote" command
+			arguments := strings.Join(curTest.Run.Cmd[j].Arguments, " ")
+			command, err := TestRemoteCommand("127.0.0.1", curTest.Port, curTest.Run.Cmd[j].Name, arguments)
 
-		// Check for any errors
-		if err != nil {
-			t.Error(err.Error())
-		}
-
-		// Parse the returned OS info for the distro and version
-		details := strings.Split(osDetails, ":")
-		distro := details[0]
-		version := details[1]
-
-		// test to see if it matches the expected distro
-		if strings.ToLower(curTest.Run.Os.DistributionID) != strings.ToLower(distro) {
-			t.Errorf("OS of the remote machine does not match the expected value: Remote OS: %s", distro)
-		}
-
-		// test to see if it matches the expected version
-		if curTest.Run.Os.Version != "" {
-			if strings.ToLower(curTest.Run.Os.Version) != strings.ToLower(version) {
-				t.Errorf("OS version of the remote machine does not match the expected value: Remote OS Version: %s", version)
+			// If we encountered any errors lets handle it.
+			if err != nil {
+				// Set the failure message
+				t.Fatalf(err.Error())
+			} else {
+				testOutput := strings.TrimSpace(command.Stdout.String())
+				// Check to see if the output from running the command matches the expected output
+				if testOutput != curTest.Run.Cmd[j].ExpectedOutput {
+					// Set the failure message
+					t.Errorf("Output of the test did not match the Expected Output (Output: %s | Expected: %s)", testOutput, curTest.Run.Cmd[j].ExpectedOutput)
+				} else {
+					t.Logf("Command \"%s\" - Passed", command.Name+" "+arguments)
+				}
 			}
 		}
 
-		//-----------------------------------------------------------------------------------------------------
+		//--------------------------------------------------------------------------------------
 
 		t.Logf("Stopping Docker Container %s", curTest.ContainerName)
 		if err = curTest.StopContainer(); err != nil {
@@ -113,20 +101,6 @@ func TestOS(t *testing.T) {
 		t.Logf("Removing Docker Container %s", curTest.ContainerName)
 		if err = curTest.RemoveContainer(); err != nil {
 			t.Fatalf("Error encountered while attempting to remove container %s: %s", curTest.ContainerName, err.Error())
-		}
-
-		if len(unitTests.UnitTests) > i+1 {
-			if unitTests.UnitTests[i+1].Image != curTest.Image {
-				t.Logf("Removing Docker Image %s", curTest.Image)
-				if err = curTest.RemoveImage(); err != nil {
-					t.Fatalf("Error encountered while attempting to remove image %s: %s", curTest.Image, err.Error())
-				}
-			}
-		} else {
-			t.Logf("Removing Docker Image %s", curTest.Image)
-			if err = curTest.RemoveImage(); err != nil {
-				t.Fatalf("Error encountered while attempting to remove image %s: %s", curTest.Image, err.Error())
-			}
 		}
 
 		// If it failed any of the command tests lets fail now before we continue to loop

--- a/tests/command/command_test.hcl
+++ b/tests/command/command_test.hcl
@@ -1,7 +1,7 @@
-unittest "SSH Command Test" {
+unittest "Command Test" {
     image = "bpalmer/ssh_test"
     port = "9090"
-    containerName = "hades-ssh-test"
+    containerName = "hades-command-test"
 
     run {
         command {
@@ -18,10 +18,10 @@ unittest "SSH Command Test" {
     }
 }
 
-unittest "SSH Command Test 2" {
+unittest "Command Test 2" {
     image = "bpalmer/ssh_test"
     port = "9090"
-    containerName = "hades-ssh-test"
+    containerName = "hades-command-test"
 
     run {
         command {

--- a/tests/command/command_test_impl.go
+++ b/tests/command/command_test_impl.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/everettraven/hades/utils"
+	"github.com/everettraven/hades/resources"
 	"golang.org/x/crypto/ssh"
 )
 
 // TestLocalCommand - Function for testing execution of a local command
-func TestLocalCommand(name string, args ...string) *utils.Command {
-	command := utils.NewCommand(name, args...)
+func TestLocalCommand(name string, args ...string) *resources.Command {
+	command := resources.NewCommand(name, args...)
 
 	err := command.RunLocal()
 	if err != nil {
@@ -24,8 +24,8 @@ func TestLocalCommand(name string, args ...string) *utils.Command {
 }
 
 // TestRemoteCommand - Function for testing execution of a remote command
-func TestRemoteCommand(host string, port string, name string, args ...string) (*utils.Command, error) {
-	command := utils.NewCommand(name, args...)
+func TestRemoteCommand(host string, port string, name string, args ...string) (*resources.Command, error) {
+	command := resources.NewCommand(name, args...)
 
 	config := &ssh.ClientConfig{
 		User:            "root",

--- a/tests/os/os_test.hcl
+++ b/tests/os/os_test.hcl
@@ -1,6 +1,6 @@
 unittest "OS Check Test without Version" {
     image = "bpalmer/ssh_test"
-    port = "9090"
+    port = "9091"
     containerName = "hades-os-test"
 
     run {
@@ -12,7 +12,7 @@ unittest "OS Check Test without Version" {
 
 unittest "OS Check Test with Version" {
     image = "bpalmer/ssh_test"
-    port = "9090"
+    port = "9091"
     containerName = "hades-os-test-version"
 
     run {

--- a/utils/test_utils.go
+++ b/utils/test_utils.go
@@ -11,12 +11,19 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
+	"github.com/everettraven/hades/resources"
 )
+
+//Command - get the Command type from resources
+type Command resources.Command
+
+//OS - get the OS type from resources
+type OS resources.OS
 
 // RunBlock is a struct to hold the data of a run block of a test
 type RunBlock struct {
 	Cmd []*Command `hcl:"command,block"`
-	Os	*OS	`hcl:"os,block"`
+	Os  *OS        `hcl:"os,block"`
 }
 
 // UnitTestUtil is a struct to hold our test data.


### PR DESCRIPTION
## Type of Change
- [x] Test
- [ ] Feature
- [ ] Internal Component
- [x] Other

## Reason for Change
Reorganized project structure to make more logical sense. All resources used in the program will be in the resources folder and all tests will be in a package in the tests folder.

Adjusted the tests to no longer include removing the Docker image that is pulled. This allows for much quicker testing time as the image is already pulled and won't have to be pulled down again from DockerHub every time the tests are run.