### PR TITLE
Add support to run tests locally

### DIFF
--- a/resources/command.go
+++ b/resources/command.go
@@ -32,12 +32,12 @@ func (c *Command) RunLocal() error {
 	c.Cmd.Stdout = &c.Stdout
 	c.Cmd.Stderr = &c.Stderr
 
-	_, err := exec.LookPath(c.Name)
+	lp, err := exec.LookPath(c.Name)
 
 	if err != nil {
 		return err
 	}
-
+	c.Cmd.Path = lp
 	err = c.Cmd.Run()
 
 	if err != nil {

--- a/resources/os.go
+++ b/resources/os.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"errors"
+	"runtime"
 	"strings"
 
 	"golang.org/x/crypto/ssh"
@@ -23,7 +24,48 @@ func GetRemoteOS(client *ssh.Client) (string, string, error) {
 
 	// Check for errors
 	if err != nil {
-		return "", "", errors.New("Could not properly run the remote command specified. Error: " + err.Error())
+		command = NewCommand("powershell", "Write-Output \"OSNAME=$(Get-ComputerInfo | % {$_.OsName})\";Write-Output \"OSVERSION=$(Get-ComputerInfo | % {$_.OsVersion})\"")
+		err = command.RunRemote(client)
+
+		if err != nil {
+			return "", "", errors.New("Error: " + err.Error())
+		}
+	}
+
+	// Get the output from the command
+	output := command.Stdout.String()
+
+	// split on the newline
+	details := strings.Split(output, "\n")
+
+	//Split on the equals sign and then trim off the quotes for both the name and version id values
+	distrib := strings.TrimSpace(strings.Split(details[0], "=")[1])
+
+	distrib = strings.Trim(distrib, "\"")
+
+	version := strings.TrimSpace(strings.Split(details[1], "=")[1])
+
+	version = strings.Trim(version, "\"")
+
+	return distrib, version, nil
+}
+
+//GetLocalOS - Get the local
+func GetLocalOS() (string, string, error) {
+	var command *Command
+	// Get the OS from the os-release file and try to get only the name and version id
+	if runtime.GOOS == "windows" {
+		command = NewCommand("powershell", "Write-Output \"OSNAME=$(Get-ComputerInfo | % {$_.OsName})\";Write-Output \"OSVERSION=$(Get-ComputerInfo | % {$_.OsVersion})\"")
+	} else {
+		command = NewCommand("bash", "-c", "cat /etc/os-release | grep -w \"NAME\\|VERSION_ID\"")
+	}
+
+	// Run the command
+	err := command.RunLocal()
+
+	// Check for errors
+	if err != nil {
+		return "", "", errors.New("Error: " + err.Error())
 	}
 
 	// Get the output from the command


### PR DESCRIPTION
## Type of Change
- [ ] Test
- [x] Feature
- [ ] Internal Component
- [ ] Other

## Reason for Change
Add capability to run the tests on the local machine by passing the `--local` flag when running hades.