### PR TITLE
add new unit tests and fix sshd check

### DIFF
--- a/tests/command/command_test.hcl
+++ b/tests/command/command_test.hcl
@@ -1,7 +1,7 @@
-unittest "Command Test" {
-    image = "bpalmer/ssh_test"
+unittest "Command Test - Ubuntu" {
+    image = "bpalmer/ubuntu-base-ssh"
     port = "9090"
-    containerName = "hades-command-test"
+    containerName = "hades-command-test-ubuntu"
 
     run {
         command {
@@ -9,19 +9,41 @@ unittest "Command Test" {
             args = ["Hello World!"]
             expectedOutput = "Hello World!"
         }
+    }
+}
 
+unittest "Command Test - Fedora" {
+    image = "bpalmer/fedora-base-ssh"
+    port = "9090"
+    containerName = "hades-command-test-fedora"
+
+    run {
         command {
-            cmd = "service"
-            args = ["ssh", "status"]
-            expectedOutput = "* sshd is running"
+            cmd = "echo"
+            args = ["World Hello!"]
+            expectedOutput = "World Hello!"
         }
     }
 }
 
-unittest "Command Test 2" {
-    image = "bpalmer/ssh_test"
+unittest "Command Test - CentOS" {
+    image = "bpalmer/centos-base-ssh"
     port = "9090"
-    containerName = "hades-command-test"
+    containerName = "hades-command-test-centos"
+
+    run {
+        command {
+            cmd = "echo"
+            args = ["World Hello!"]
+            expectedOutput = "World Hello!"
+        }
+    }
+}
+
+unittest "Command Test - Alpine" {
+    image = "bpalmer/alpine-base-ssh"
+    port = "9090"
+    containerName = "hades-command-test-alpine"
 
     run {
         command {

--- a/tests/os/os_test.hcl
+++ b/tests/os/os_test.hcl
@@ -1,7 +1,7 @@
-unittest "OS Check Test without Version" {
-    image = "bpalmer/ssh_test"
+unittest "OS Check Test without Version - Ubuntu" {
+    image = "bpalmer/ubuntu-base-ssh"
     port = "9091"
-    containerName = "hades-os-test"
+    containerName = "hades-os-test-ubuntu"
 
     run {
         os {
@@ -10,15 +10,90 @@ unittest "OS Check Test without Version" {
     }
 }
 
-unittest "OS Check Test with Version" {
-    image = "bpalmer/ssh_test"
+unittest "OS Check Test with Version - Ubuntu" {
+    image = "bpalmer/ubuntu-base-ssh"
     port = "9091"
-    containerName = "hades-os-test-version"
+    containerName = "hades-os-test-version-ubuntu"
 
     run {
         os {
             distributionID = "ubuntu"
             version = "20.04"
+        }
+    }
+}
+
+unittest "OS Check Test without Version - Fedora" {
+    image = "bpalmer/fedora-base-ssh"
+    port = "9091"
+    containerName = "hades-os-test-fedora"
+
+    run {
+        os {
+            distributionID = "fedora"
+        }
+    }
+}
+
+unittest "OS Check Test with Version - Fedora" {
+    image = "bpalmer/fedora-base-ssh"
+    port = "9091"
+    containerName = "hades-os-test-version-fedora"
+
+    run {
+        os {
+            distributionID = "fedora"
+            version = "33"
+        }
+    }
+}
+
+unittest "OS Check Test without Version - CentOS" {
+    image = "bpalmer/centos-base-ssh"
+    port = "9091"
+    containerName = "hades-os-test-centos"
+
+    run {
+        os {
+            distributionID = "centos linux"
+        }
+    }
+}
+
+unittest "OS Check Test with Version - CentOS" {
+    image = "bpalmer/centos-base-ssh"
+    port = "9091"
+    containerName = "hades-os-test-version-centos"
+
+    run {
+        os {
+            distributionID = "centos linux"
+            version = "8"
+        }
+    }
+}
+
+unittest "OS Check Test without Version - Alpine" {
+    image = "bpalmer/alpine-base-ssh"
+    port = "9091"
+    containerName = "hades-os-test-alpine"
+
+    run {
+        os {
+            distributionID = "alpine linux"
+        }
+    }
+}
+
+unittest "OS Check Test with Version - Alpine" {
+    image = "bpalmer/alpine-base-ssh"
+    port = "9091"
+    containerName = "hades-os-test-version-alpine"
+
+    run {
+        os {
+            distributionID = "alpine linux"
+            version = "3.12.3"
         }
     }
 }

--- a/utils/test_utils.go
+++ b/utils/test_utils.go
@@ -250,41 +250,13 @@ func (test *UnitTestUtil) SSHDRunning() (bool, error) {
 		return false, err
 	}
 
-	cmd := []string{"service", "ssh", "status"}
+	resp, err := cli.ContainerTop(ctx, test.ContainerID, nil)
 
-	config := types.ExecConfig{
-		AttachStderr: true,
-		AttachStdout: true,
-		Cmd:          cmd,
-	}
-
-	// Create the exec command and run it
-	execID, err := cli.ContainerExecCreate(ctx, test.ContainerID, config)
-
-	// error check
 	if err != nil {
 		return false, err
 	}
 
-	// Get the details from the previously ran exec command
-	resp, err := cli.ContainerExecAttach(ctx, execID.ID, types.ExecStartCheck{})
-	defer cli.Close()
-
-	// error check
-	if err != nil {
-		return false, err
-	}
-
-	// get the output from the exec command until we hit a newline character
-	execOut, err := resp.Reader.ReadString('\n')
-
-	// error check
-	if err != nil {
-		return false, err
-	}
-
-	// check if the output contains "is running" to signify that the SSHD service is actually running within the container
-	if strings.Contains(execOut, "is running") {
+	if strings.Contains(resp.Processes[0][3], "sshd") {
 		running = true
 	}
 


### PR DESCRIPTION
## Type of Change
- [x] Test
- [ ] Feature
- [ ] Internal Component
- [ ] Other

## Reason for Change
Added more unit tests to check if hades resources would work one Fedora, CentOS, Ubuntu, and Alpine. Also fixed `SSHDRunning()` function in the `test_utils.go` file. Made it use the Docker SDK ContainerTop function and check if the sshd process is running. This eliminates the potential of differing service checks in the different OS containers.